### PR TITLE
Fix missing ru translations in sentence segment builder

### DIFF
--- a/src/components/VideoPlayer/halpers.ts
+++ b/src/components/VideoPlayer/halpers.ts
@@ -7,7 +7,7 @@ const thaiChar = /[\u0E00-\u0E7F]/;
 /**
  * Разбивает поток слов на предложения и прикрепляет переводы из исходных сегментов.
  * Для тайского языка дополнительно разбивает по пробелам между тайскими символами.
- * Переводы сохраняются в ключах { en, th }.
+ * Переводы сохраняются в ключах { en, th, ru }.
  */
 export function buildSentenceSegments(src: SubtitleData): SubtitleData {
   // 1) Поток всех слов
@@ -16,9 +16,20 @@ export function buildSentenceSegments(src: SubtitleData): SubtitleData {
   // 2) Соединяем переводы всех исходных сегментов в единые тексты
   const fullEn = src.segments.map(s => s.translations.en).join(' ');
   const fullTh = src.segments.map(s => s.translations.th).join(' ');
+  const fullRu = src.segments.map(s => s.translations.ru).join(' ');
 
   // 3) Разбиение английского текста на предложения по знакам
   const enSentences = fullEn
+    .split(/([.!?…]+)/)
+    .reduce<string[]>((acc, tok) => {
+      if (!tok.trim()) return acc;
+      if (sentenceEnd.test(tok) && acc.length) acc[acc.length - 1] += tok;
+      else acc.push(tok);
+      return acc;
+    }, [])
+    .map(s => s.replace(/^\s*[.!?…]+\s*/, '').trim());
+
+  const ruSentences = fullRu
     .split(/([.!?…]+)/)
     .reduce<string[]>((acc, tok) => {
       if (!tok.trim()) return acc;
@@ -55,6 +66,7 @@ export function buildSentenceSegments(src: SubtitleData): SubtitleData {
         translations: {
           en: enSentences[sentenceSegs.length] || '',
           th: thSentences[sentenceSegs.length] || '',
+          ru: ruSentences[sentenceSegs.length] || '',
         },
       });
       buff = [];


### PR DESCRIPTION
## Summary
- preserve Russian translations when splitting subtitles into sentences

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build` *(fails: missing dependencies for tsc)*

------
https://chatgpt.com/codex/tasks/task_e_683fa83960b8832fa23e29a854b872bb