### PR TITLE
Implement animated drag-and-drop for SentenceExercise

### DIFF
--- a/src/components/SentenceExercise.tsx
+++ b/src/components/SentenceExercise.tsx
@@ -1,5 +1,7 @@
 // src/components/exercises/SentenceExercise.tsx
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState, useRef, useCallback } from 'react';
+import { useDrag, useDrop, useDragLayer } from 'react-dnd';
+import { getEmptyImage } from 'react-dnd-html5-backend';
 
 interface Sentence {
   text: string; // Полное предложение на тайском, например: "นี่คือข้อเสนอการทดสอบสำหรับการตรวจสอบ"
@@ -27,6 +29,154 @@ type DraggableWord = {
   correctIndex: number; // Позиция в «правильном ответе»
 };
 
+// Элемент перетаскивания с указанием его текущего списка
+type DragItem = DraggableWord & { fromList: boolean; width: number };
+
+const ITEM_TYPE = 'WORD';
+
+// Компонент для кастомного слоя перетаскивания
+const DragPreview: React.FC = () => {
+  const { itemType, item, isDragging, currentOffset } = useDragLayer(monitor => ({
+    itemType: monitor.getItemType(),
+    item: monitor.getItem() as DragItem | null,
+    isDragging: monitor.isDragging(),
+    currentOffset: monitor.getSourceClientOffset(),
+  }));
+
+  if (!isDragging || itemType !== ITEM_TYPE || !currentOffset || !item) return null;
+
+  const { x, y } = currentOffset;
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        pointerEvents: 'none',
+        left: x,
+        top: y,
+        transform: 'translate(-50%, -50%)',
+        zIndex: 1000,
+      }}
+    >
+      <div className="px-3 py-1 bg-gray-200 rounded shadow">
+        {item.text}
+      </div>
+    </div>
+  );
+};
+
+interface WordChipProps {
+  word: DraggableWord;
+  fromList: boolean; // где находится слово в данный момент
+  disabled: boolean;
+  colorClass?: string; // цвет фона
+  index?: number; // позиция слова в пользовательской зоне
+  moveWord?: (dragIndex: number, hoverIndex: number) => void; // перестановка
+  insertWordFromList?: (word: DraggableWord, at: number) => void; // вставка слова из списка
+}
+
+// Универсальный чип, который может перетаскиваться между двумя списками
+const WordChip: React.FC<WordChipProps> = ({
+  word,
+  fromList,
+  disabled,
+  colorClass,
+  index,
+  moveWord,
+  insertWordFromList,
+}) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const [hoverPos, setHoverPos] = useState<'left' | 'right' | null>(null);
+  const [dragWidth, setDragWidth] = useState(0);
+
+  const [{ isDragging }, drag, preview] = useDrag<DragItem & { index?: number }, void, { isDragging: boolean }>(
+    () => ({
+      type: ITEM_TYPE,
+      item: () => {
+        const width = ref.current?.offsetWidth || 0;
+        return { ...word, fromList, index, width };
+      },
+      canDrag: !disabled,
+      end: () => {
+        setHoverPos(null);
+      },
+    }),
+    [word, fromList, disabled, index],
+  );
+
+  const [{ isOver }, drop] = useDrop<DragItem & { index?: number }>(
+    () => ({
+      accept: ITEM_TYPE,
+      drop: (item, monitor) => {
+        setHoverPos(null);
+        if (!monitor.isOver({ shallow: true })) return;
+        if (!fromList && item.fromList && insertWordFromList && index !== undefined) {
+          const at = hoverPos === 'right' ? index + 1 : index;
+          insertWordFromList(item, at);
+          item.fromList = false;
+          item.index = at;
+          return { handled: true };
+        }
+      },
+      hover: (item, monitor) => {
+        if (!ref.current) return;
+        const rect = ref.current.getBoundingClientRect();
+        const middleX = (rect.right - rect.left) / 2;
+        const client = monitor.getClientOffset();
+        if (!client) return;
+        const offsetX = client.x - rect.left;
+        const pos = offsetX < middleX ? 'left' : 'right';
+        setHoverPos(pos);
+        setDragWidth(item.width);
+
+        if (!moveWord || fromList || item.fromList) return;
+        if (item.index === undefined || index === undefined) return;
+        const targetIndex = pos === 'left' ? index : index + 1;
+        if (targetIndex === item.index || targetIndex - 1 === item.index) return;
+        const newIndex = targetIndex > item.index ? targetIndex - 1 : targetIndex;
+        moveWord(item.index, newIndex);
+        item.index = newIndex;
+      },
+      collect: monitor => ({
+        isOver: monitor.isOver({ shallow: true }),
+      }),
+    }),
+    [moveWord, fromList, index, insertWordFromList, hoverPos],
+  );
+
+  useEffect(() => {
+    if (!isOver) setHoverPos(null);
+  }, [isOver]);
+
+  // Скрываем стандартный drag preview
+  useEffect(() => {
+    preview(getEmptyImage(), { captureDraggingState: true });
+  }, [preview]);
+
+  return (
+    <div
+      ref={node => {
+        ref.current = node;
+        if (fromList) {
+          drag(node as HTMLDivElement);
+        } else {
+          drag(drop(node as HTMLDivElement));
+        }
+      }}
+      style={{
+        opacity: isDragging ? 0 : 1,
+        transition: 'all 0.3s ease-out',
+        marginLeft: hoverPos === 'left' ? dragWidth : 0,
+        marginRight: hoverPos === 'right' ? dragWidth : 0,
+      }}
+      className={`px-3 py-1 rounded cursor-move select-none ${colorClass || 'bg-gray-200'}`}
+      data-interactive="true"
+    >
+      {word.text}
+    </div>
+  );
+};
+
 export default function SentenceExercise({ sentence, onComplete, isActive, index }: Props) {
   const [shuffled, setShuffled] = useState<DraggableWord[]>([]);
   const [userOrder, setUserOrder] = useState<DraggableWord[]>([]);
@@ -34,6 +184,64 @@ export default function SentenceExercise({ sentence, onComplete, isActive, index
   const [feedback, setFeedback] = useState<boolean[]>([]); // true = правильно, false = неправильно
 
   const dropZoneRef = useRef<HTMLDivElement>(null);
+
+  const moveWord = useCallback(
+    (from: number, to: number) => {
+      setUserOrder(prev => {
+        const updated = [...prev];
+        const [moved] = updated.splice(from, 1);
+        updated.splice(to, 0, moved);
+        return updated;
+      });
+    },
+    [],
+  );
+
+  const insertWordFromList = useCallback((word: DraggableWord, at: number) => {
+    setShuffled(prev => prev.filter(w => w.id !== word.id));
+    setUserOrder(prev => {
+      const updated = [...prev];
+      updated.splice(at, 0, word);
+      return updated;
+    });
+  }, []);
+
+  // Зона для составления предложения
+  const [{ isOver }, dropToUser] = useDrop<DragItem, void, { isOver: boolean }>(
+    () => ({
+      accept: ITEM_TYPE,
+      drop: (item, monitor) => {
+        if (monitor.didDrop()) return;
+        if (item.fromList && !userOrder.find(w => w.id === item.id)) {
+          // перенос из общего списка в конец, если не попали на слово
+          setShuffled(prev => prev.filter(w => w.id !== item.id));
+          setUserOrder(prev => [...prev, item]);
+        }
+      },
+      collect: monitor => ({
+        isOver: monitor.isOver({ shallow: true }),
+      }),
+    }),
+    [userOrder, shuffled],
+  );
+
+  // Зона со всеми словами
+  const [{ isOver: isOverList }, dropToList] = useDrop<DragItem, void, { isOver: boolean }>(
+    () => ({
+      accept: ITEM_TYPE,
+      drop: (item: DragItem) => {
+        if (!item.fromList) {
+          // перенос из пользовательского поля обратно в список
+          setUserOrder(prev => prev.filter(w => w.id !== item.id));
+          setShuffled(prev => [...prev, item]);
+        }
+      },
+      collect: monitor => ({
+        isOver: monitor.isOver({ shallow: true }),
+      }),
+    }),
+    [userOrder, shuffled],
+  );
 
   // При инициализации разбиваем текст на тайские «слова» через Intl.Segmenter
   useEffect(() => {
@@ -60,27 +268,6 @@ export default function SentenceExercise({ sentence, onComplete, isActive, index
     setFeedback([]);
   }, [sentence.text, isActive, index]);
 
-  // Обработчики Drag&Drop
-  const handleDragStart = (e: React.DragEvent<HTMLDivElement>, draggedWord: DraggableWord) => {
-    e.dataTransfer.setData('application/json', JSON.stringify(draggedWord));
-    e.dataTransfer.effectAllowed = 'move';
-  };
-
-  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    const data = e.dataTransfer.getData('application/json');
-    if (!data) return;
-    const droppedWord: DraggableWord = JSON.parse(data);
-
-    // Если слово уже добавлено пользователем — не добавляем снова
-    if (userOrder.find(w => w.id === droppedWord.id)) return;
-
-    setUserOrder(prev => [...prev, droppedWord]);
-  };
-
-  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
-    e.preventDefault();
-  };
 
   // Проверка: нажали «Проверить»
   const handleCheck = () => {
@@ -106,6 +293,7 @@ export default function SentenceExercise({ sentence, onComplete, isActive, index
 
   // Сброс текущего поля (например, перед проверкой нового предложения)
   const handleReset = () => {
+    setShuffled(prev => [...prev, ...userOrder]);
     setUserOrder([]);
     setIsChecked(false);
     setFeedback([]);
@@ -123,40 +311,52 @@ export default function SentenceExercise({ sentence, onComplete, isActive, index
           <p className="mb-2">Соберите предложение:</p>
 
           {/* Зона со словарными чипсами (перемешано) */}
-          <div className="flex flex-wrap gap-2 mb-4">
+          <div
+            ref={node => {
+              dropToList(node as HTMLDivElement);
+            }}
+            className={`flex flex-wrap gap-2 mb-4 border-2 border-dashed rounded ${isOverList ? 'border-yellow-400' : 'border-transparent'}`}
+          >
             {shuffled.map(wordObj => (
-              <div
+              <WordChip
                 key={wordObj.id}
-                draggable={!isChecked}
-                onDragStart={e => handleDragStart(e, wordObj)}
-                className="px-3 py-1 bg-gray-200 rounded cursor-move select-none"
-              >
-                {wordObj.text}
-              </div>
+                word={wordObj}
+                fromList={true}
+                disabled={isChecked}
+              />
             ))}
           </div>
 
           {/* Поле пользователя (куда перетаскивают слова) */}
           <div
-            ref={dropZoneRef}
-            onDrop={handleDrop}
-            onDragOver={handleDragOver}
-            className="min-h-[48px] border-2 border-dashed border-gray-300 rounded p-2 mb-4 flex flex-wrap gap-2"
+            ref={node => {
+              dropToUser(node as HTMLDivElement);
+              dropZoneRef.current = node;
+            }}
+            className={`min-h-[48px] border-2 border-dashed rounded p-2 mb-4 flex flex-wrap gap-2 ${isOver ? 'border-yellow-400' : 'border-gray-300'}`}
           >
             {userOrder.length === 0 && (
               <span className="text-gray-400">Перетащите сюда слова...</span>
             )}
-            {userOrder.map((w, idx) => (
-              <span
-                key={w.id}
-                className={`
-                  px-3 py-1 rounded select-none
-                  ${isChecked ? (feedback[idx] ? 'bg-green-300' : 'bg-red-300') : 'bg-yellow-100'}
-                `}
-              >
-                {w.text}
-              </span>
-            ))}
+            {userOrder.map((w, idx) => {
+              const color = isChecked
+                ? feedback[idx]
+                  ? 'bg-green-300'
+                  : 'bg-red-300'
+                : 'bg-yellow-100';
+              return (
+                <WordChip
+                  key={w.id}
+                  word={w}
+                  fromList={false}
+                  disabled={isChecked}
+                  colorClass={color}
+                  index={idx}
+                  moveWord={moveWord}
+                  insertWordFromList={insertWordFromList}
+                />
+              );
+            })}
           </div>
 
           {/* Кнопки «Проверить» и «Сброс» */}
@@ -200,7 +400,8 @@ export default function SentenceExercise({ sentence, onComplete, isActive, index
               </p>
             )}
           </div>
-        </>
+        <DragPreview />
+      </>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- use `react-dnd` with a custom drag layer
- create a `WordChip` component for draggable words
- remove dragged words from the list while dragging and show preview near cursor
- animate margins when reordering words via drag and drop

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.(js|mjs|cjs) file)*
- `npm run build` *(fails to compile due to TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_683fb428b250832f929d7932aa15e639